### PR TITLE
Simplify Code

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -3,7 +3,6 @@
 import time 
 import datetime
 from os import environ
-import os
 import platform
 
 #shell
@@ -16,15 +15,11 @@ up=str(datetime.timedelta(seconds=uptime)) # 0:00:00.000000
 # hostname
 with open("/etc/hostname", "r") as host:
     # With blocks ensure that the file will get closed
-    hostname = host.read()
-    hostname = hostname.strip()
+    hostname = host.read().strip()
 
 # distro
 with open("/etc/issue", "r") as distro:
-    distrob = distro.read()
-    distrob = distrob.strip()
-    distrob = distrob.replace("(\l)","")
-    distrob = distrob.replace("\\r","")
+    distrob = distro.read().strip().replace("(\l)","").replace("\\r","")
 
 # kernel
 kernel = platform.release()
@@ -33,12 +28,12 @@ kernel = platform.release()
 # terminal = os.ctermid()
 
 def structure():
-    print(f"\n(\_/) \033[0;33m     uptime:      %s\033[0;0m" % (up)) #orange
-    print(f"(oᴥo) \033[0;31m     shell:       %s\033[0;0m" % (shell)) #red
-    print(f"|U°U| \033[0;35m     distro:      %s\033[0;0m" % (distrob)) #purple
-    print(f"|   | \033[0;34m     hostname:    %s\033[0;0m" % (hostname)) #blue
-    print(f"'U_U' \033[0;36m     kernel:      %s\033[0;0m" % (kernel)) #cyan
-    print(f"  U" ) # dont work proprerly ## code from before i gave up the terminal detection:  \033[1;32m     terminal:    %s\033[0;0m" % (terminal)
+    print("\n(\_/) \033[0;33m     uptime:      %s\033[0;0m" % (up)) #orange
+    print("(oᴥo) \033[0;31m     shell:       %s\033[0;0m" % (shell)) #red
+    print("|U°U| \033[0;35m     distro:      %s\033[0;0m" % (distrob)) #purple
+    print("|   | \033[0;34m     hostname:    %s\033[0;0m" % (hostname)) #blue
+    print("'U_U' \033[0;36m     kernel:      %s\033[0;0m" % (kernel)) #cyan
+    print("  U" ) # dont work proprerly ## code from before i gave up the terminal detection:  \033[1;32m     terminal:    %s\033[0;0m" % (terminal)
     # terminal => os.ctermid()
 
 


### PR DESCRIPTION
This commit, simplifies the file reading code, removes the (as of now) useless import "os" and uses normal strings instead of "f-strings".

Has been tested on Debian 12 WSL.